### PR TITLE
Included instructions for Glitch v6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ Include the following in a new line below `"scripts": {`:
 ```
 "preinstall": "npm install --save node@12.16.3",
 ```
+
+If you want the web UI, you will need to replace `server.js` in the start script with `bot-web.js`.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,4 @@ Include the following in a new line below `"scripts": {`:
 
 If you want the web UI, you will need to add the following in a file named .env:
 
-```
-DRSS_START=bot-web
-```
+![image](https://user-images.githubusercontent.com/44692189/82736173-5b68f500-9d49-11ea-9e42-9b23af184438.png)

--- a/README.md
+++ b/README.md
@@ -51,4 +51,8 @@ Include the following in a new line below `"scripts": {`:
 "preinstall": "npm install --save node@12.16.3",
 ```
 
-If you want the web UI, you will need to replace `server.js` in the start script with `bot-web.js`.
+If you want the web UI, you will need to add the following in a file named .env:
+
+```
+DRSS_START=bot-web
+```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Click the button below to import the code to Glitch. Wait for the importing proc
 
 You can use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) for the MongoDB database and [Redis Labs](https://redislabs.com/) for the Redis database.
 
-The web port for Glitch is 3000.
-
 Discord.RSS requires node.js v12.16. As of 23 May 2020, Glitch currently does not install v12.16 automatically, and must be manually installed. For Discord.RSS to work on Glitch, you will need to modify the scripts section to manually install v12.16.
 
 Include the following in a new line below `"scripts": {`:
@@ -51,6 +49,8 @@ Include the following in a new line below `"scripts": {`:
 "preinstall": "npm install --save node@12.16.3",
 ```
 
-If you want the web UI, you will need to add the following in a file named .env:
+If you want the web UI, you will need to follow the [web configuration](https://docs.discordrss.xyz/configuration/web-interface) and add the following in a file named .env:
 
 ![image](https://user-images.githubusercontent.com/44692189/82736173-5b68f500-9d49-11ea-9e42-9b23af184438.png)
+
+The web port for Glitch is 3000.

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ You can deploy the bot in a simple way to Heroku using the button below. [Click 
 
 <!-- [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy) -->
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?button-url=https://github.com/synzen/Discord.RSS-Clone&template=https://github.com/synzen/Discord.RSS-Clone/tree/dev)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?button-url=https://github.com/synzen/Discord.RSS-Clone&template=https://github.com/synzen/Discord.RSS-Clone/tree/master)
 
 *If you want to deploy manually you can [follow this guide](https://github.com/synzen/Discord.RSS/issues/95).*
 
 ### Hosting on Glitch
 
-Click the button below to import the code to Glitch. Wait for the importing process to complete, make your project private and fill in the [Configuration](https://github.com/synzen/Discord.RSS/wiki/Configuration). Use a tool like [Uptime Robot](https://uptimerobot.com/) to prevent the bot from going offline.
+Click the button below to import the code to Glitch. Wait for the importing process to complete, make your project private and fill in the [Configuration](https://docs.discordrss.xyz/configuration/bot-configuration). Use a tool like [Uptime Robot](https://uptimerobot.com/) to prevent the bot from going offline.
 
 [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/import/github/synzen/Discord.RSS-Clone)
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,10 @@ You can use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) for the MongoDB
 
 The web port for Glitch is 3000.
 
-You will also need to modify the scripts section of the package.json in order for the bot to work properly on Glitch.
+Discord.RSS requires node.js v12.16. As of 23 May 2020, Glitch currently does not install v12.16 automatically, and must be manually installed. For Discord.RSS to work on Glitch, you will need to modify the scripts section to manually install v12.16.
 
-Replace the lines starting from `"scripts": {` and ending in `},` with:
+Include the following in a new line below `"scripts": {`:
 
 ```
-  "scripts": {
-    "preinstall": "npm install --save node@12.16.3",
-    "migrate-v6": "node migrations/v6.js",
-    "start": "node bot-web.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+"preinstall": "npm install --save node@12.16.3",
 ```

--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@ Click the button below to import the code to Glitch. Wait for the importing proc
 You can use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) for the MongoDB database and [Redis Labs](https://redislabs.com/) for the Redis database.
 
 The web port for Glitch is 3000.
+
+You will also need to modify the scripts section of the package.json in order for the bot to work properly on Glitch.
+
+Replace the lines starting from `"scripts": {` and ending in `},` with:
+
+```
+  "scripts": {
+    "preinstall": "npm install --save node@12.16.3",
+    "migrate-v6": "node migrations/v6.js",
+    "start": "node bot-web.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+```


### PR DESCRIPTION
Idk whether to put them as instructions in the readme or just submit a PR of a modified package.json, so putting them as readme instructions 😛

I also pointed the Heroku button to the master branch instead of dev and update the config link in the Glitch instructions to point to the Discord.RSS documentation site.