### PR TITLE
Add config.bot.clientId to config.bot.example.json + DRSS_FEEDS_DEFAULTTEXT to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ DRSS_BOT_PREFIX=~
 DRSS_BOT_OWNERIDS=
 DRSS_DATABASE_URI=
 DRSS_FEEDS_REFRESHRATEMINUTES=15
-DRSS_FEEDS_DEFAULTMESSAGE=:newspaper:  |  **{title}**\n\n{link}\n\n{subscriptions}
+DRSS_FEEDS_DEFAULTTEXT=:newspaper:  |  **{title}**\n\n{link}\n\n{subscriptions}

--- a/settings/config.bot.example.json
+++ b/settings/config.bot.example.json
@@ -8,6 +8,7 @@
     "failedFeeds": true
   },
   "bot": {
+    "clientId": "",
     "token": "",
     "locale": "en-US",
     "enableCommands": true,


### PR DESCRIPTION
- `config.bot.clientId` is needed since `6.14.9-beta.12`
- Renamed `DRSS_FEEDS_DEFAULTMESSAGE` to `DRSS_FEEDS_DEFAULTTEXT` for .env.example