### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,6 @@
 name: Docker Image CI
 
 on:
-  workflow_dispatch
   push:
     branches: [ dev, master ]
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,7 +52,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ steps.<meta_id>.outputs.tags }}
+          tags: ${{ steps.mrss.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          platforms: linux/amd64,linux/arm/v7
+          platforms: linux/amd64
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,9 @@
 name: Docker Image CI
 
 on:
+  workflow_dispatch
   push:
-    branches: [ master ]
+    branches: [ dev, master ]
 
 jobs:
   push_to_registry:
@@ -19,26 +20,40 @@ jobs:
 
       - name: Check out the repo
         uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
       
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: mrss
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ secrets.DOCKER_USERNAME }}/monitorss
+          tags: |
+            type=ref,event=branch
+            type=sha
       
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: ./
+          platforms: linux/amd64,linux/arm/v7
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/monitorss:latest
+          tags: ${{ steps.<meta_id>.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
Fix for build errors related to the Dockerfile base image repositories falling out of support.
#44 

More conversation around the issue here
https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found

note: I see that `dev` is a bit out of sync with `master`, this change will also need to be applied there, or `master` merged back. Whatever would be appropriate for the gitrepo's structure.