### PR TITLE
Fix build issues - stretch repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:12-stretch AS build
 
+#Update stretch repositories
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list \
+    && sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y \
         g++ \
         git \


### PR DESCRIPTION
Fix for build errors related to the Dockerfile base image repositories falling out of support.
https://github.com/synzen/MonitoRSS-Clone/issues/44

More conversation around the issue here
https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found

note: I see that dev is a bit out of sync with master, this change will also need to be applied there, or master merged back. Whatever would be appropriate for the gitrepo's structure.